### PR TITLE
Remove reference to specific tools

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -274,7 +274,7 @@ The following is an example of the DIMENSIONS key from the PCMDI Metrics Package
     }
 },
 ```
-Developers should consider minimizing the number of dimensions used for compatibility with the JavaScript-based visualization module. Currently, files with up to 4 dimensions are compatible with the visualization module. 
+Developers should consider minimizing the number of dimensions used for compatibility with visualization tools and general ease of use. 
 
 ### RESULTS <a name="results"></a>
 


### PR DESCRIPTION
This is an update to incorporate a change from a comment in PR1 that did not get picked up. I've removed a reference to a CMEC specific web visualization tool and changed the line to more generally discourage large numbers of dimensions.